### PR TITLE
Feat/standardize property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,29 +46,37 @@ jThumbnailer.close();
 
 | Configuration Args                       | Description                                                         |
 | ---------------------------------------- |---------------------------------------------------------------------|
+| **OpanAPI properties**                   |                                                                     |
+| jthumbnailer.openapi.name                | Application name, e.g. Java Thumbnail Generator in Swagger UI       |
+| jthumbnailer.openapi.desc                | Description of the application in Swagger UI                        |
+| jthumbnailer.openapi.license             | License of the application as displayed in Swagger UI               |
+| jthumbnailer.openapi.url                 | URL pointing to the license text for Swagger UI                     |
 | **OPENOFFICE Properties**                |                                                                     |
-| jthumbnailer.name                        | Application name, e.g. Java Thumbnail Generator                     |
-| jthumbnailer.openoffice.port             | Ports used by OpenOffice for document conversion                    |
+| jthumbnailer.openoffice.ports            | Ports used by OpenOffice for document conversion                    |
 | jthumbnailer.openoffice.timeout          | Timeout for OpenOffice document conversion tasks                    |
 | jthumbnailer.openoffice.max_tasks_per_process | Maximum number of conversion tasks allowed per OpenOffice process   |
-| jthumbnailer.openoffice.dir              | Directory path to the OpenOffice installation                       |
-| jthumbnailer.openoffice.tmp              | Directory path for temporary files generated and used by OpenOffice |
+| jthumbnailer.openoffice.office_home      | Directory path to the OpenOffice installation                       |
+| jthumbnailer.openoffice.working_dir      | Working directory path for OpenOffice                               |
+| jthumbnailer.openoffice.tmp_dir          | Directory path for temporary files generated and used by OpenOffice |
 | **JTHUMBNAILER Properties**              |                                                                     |
-| jthumbnailer.thumb_width                 | Width of generated thumbnails                                       |
-| jthumbnailer.thumb_height                | Height of generated thumbnails                                      |
+| jthumbnailer.thumbnail.thumb_width       | Width of generated thumbnails                                       |
+| jthumbnailer.thumbnail.thumb_height      | Height of generated thumbnails                                      |
+| **JTHUMBNAILER Async Properties          |                                                                     |
 | jthumbnailer.async.core_pool_size        | Core pool size for the asynchronous processing tasks                |
-| jthumbnailer.async.max_pool_size          | Maximum pool size for the asynchronous processing tasks             |
-| **Spring**                                |                                                                     |
-| spring.servlet.multipart.max-file-size    | Maximum allowed file size for multipart file uploads                |
-| spring.servlet.multipart.max-request-size | Maximum allowed request size for multipart file uploads             |
-| server.port                               | Port on which the application will be hosted                        |
-| **Spring Doc**                            |                                                                     |
+| jthumbnailer.async.max_pool_size         | Maximum pool size for the asynchronous processing tasks             |
+| **JTHUMBNAILER Server Properties**       |                                                                     |
+| jthumbnailer.server.upload_directory     | Directory used to store uploads when using API                      |
+| jthumbnailer.server.max_waiting_list_size| Queue for files to be processed                                     |
+| **Spring**                               |                                                                     |
+| spring.servlet.multipart.max-file-size   | Maximum allowed file size for multipart file uploads                |
+| spring.servlet.multipart.max-request-size| Maximum allowed request size for multipart file uploads             |
+| server.port                              | Port on which the Web application will be hosted                    |
+| **Spring Doc**                           |                                                                     |
 | springdoc.api-docs.path                  | Path for accessing the API documentation in JSON format             |
 | springdoc.swagger-ui.path                | Path for accessing the Swagger UI for interactive API documentation |
 
-- All parameters can be passed through the environment variables. To pass a param as environment variable you need to
-remove the dots and make the first characters upper case. For example, `jthumbnailer.openoffice.dir` should be 
-`JthumbnailerOpenofficeDir`.
+- All parameters can be passed through environment variables. To pass a param as environment variable you need to replace the dots with underscore and use uppercase. For example, `jthumbnailer.openoffice.office_home` should be 
+`JTHUMBNAILER_OPENOFFICE_OFFICEHOME` (see [Spring documentation](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.relaxed-binding).
 
 ## Requirements
 

--- a/build.gradle
+++ b/build.gradle
@@ -127,16 +127,20 @@ spotless {
     }
 
     java {
-        // clean and format imports
-        removeUnusedImports()
-        removeWildcardImports()
-        importOrder()
 
-        // fix formatting of type annotations
+         trimTrailingWhitespace()
+
+         // fix formatting of type annotations
         formatAnnotations()
 
         // Format sources and javadocs according to Palantir formatter
         palantirJavaFormat()
+
+
+        // clean and format imports
+        removeUnusedImports()
+        // removeWildcardImports()
+        importOrder('', 'org', 'com', '#', 'java', 'javax')
 
         // make sure every file has the following copyright header.
         // optionally, Spotless can set copyright years by digging

--- a/src/main/java/io/github/makbn/jthumbnail/JThumbnailerStarter.java
+++ b/src/main/java/io/github/makbn/jthumbnail/JThumbnailerStarter.java
@@ -1,12 +1,14 @@
 package io.github.makbn.jthumbnail;
 
 import io.github.makbn.jthumbnail.core.JThumbnailer;
-import java.util.Arrays;
+
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Arrays;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan

--- a/src/main/java/io/github/makbn/jthumbnail/api/OpenAPIDocumentConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/api/OpenAPIDocumentConfiguration.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/io/github/makbn/jthumbnail/api/controller/ThumbnailController.java
+++ b/src/main/java/io/github/makbn/jthumbnail/api/controller/ThumbnailController.java
@@ -11,11 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -31,6 +29,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
 
 @CrossOrigin("*")
 @RestController

--- a/src/main/java/io/github/makbn/jthumbnail/api/model/JThumbnailApiResponse.java
+++ b/src/main/java/io/github/makbn/jthumbnail/api/model/JThumbnailApiResponse.java
@@ -1,10 +1,10 @@
 package io.github.makbn.jthumbnail.api.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.net.HttpURLConnection;
-
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+
+import java.net.HttpURLConnection;
 
 @Data
 @Builder

--- a/src/main/java/io/github/makbn/jthumbnail/api/model/Thumbnail.java
+++ b/src/main/java/io/github/makbn/jthumbnail/api/model/Thumbnail.java
@@ -1,10 +1,11 @@
 package io.github.makbn.jthumbnail.api.model;
 
-import java.io.File;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+
+import java.io.File;
 
 @Builder
 @Getter

--- a/src/main/java/io/github/makbn/jthumbnail/api/service/ThumbnailService.java
+++ b/src/main/java/io/github/makbn/jthumbnail/api/service/ThumbnailService.java
@@ -5,19 +5,21 @@ import io.github.makbn.jthumbnail.core.JThumbnailer;
 import io.github.makbn.jthumbnail.core.config.ThumbnailServerConfiguration;
 import io.github.makbn.jthumbnail.core.model.ThumbnailCandidate;
 import io.github.makbn.jthumbnail.core.model.ThumbnailEvent;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import lombok.AccessLevel;
-import lombok.NonNull;
-import lombok.experimental.FieldDefaults;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Log4j2
 @Service
@@ -141,7 +143,6 @@ public class ThumbnailService {
         multipartFile.transferTo(tempFile);
         return tempFile;
     }
-
 
     /**
      * Creates a thread-safe {@link Map} with a bounded size, implemented using a

--- a/src/main/java/io/github/makbn/jthumbnail/core/JThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/JThumbnailer.java
@@ -6,14 +6,16 @@ import io.github.makbn.jthumbnail.core.listener.ThumbnailListener;
 import io.github.makbn.jthumbnail.core.model.ThumbnailCandidate;
 import io.github.makbn.jthumbnail.core.model.ThumbnailEvent;
 import io.github.makbn.jthumbnail.core.util.mime.MimeTypeDetector;
-import java.io.Closeable;
-import java.io.File;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
+
+import java.io.Closeable;
+import java.io.File;
 
 @Component
 @EnableAsync

--- a/src/main/java/io/github/makbn/jthumbnail/core/ThumbnailerManager.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/ThumbnailerManager.java
@@ -5,6 +5,15 @@ import io.github.makbn.jthumbnail.core.exception.ThumbnailRuntimeException;
 import io.github.makbn.jthumbnail.core.model.ExecutionResult;
 import io.github.makbn.jthumbnail.core.thumbnailers.Thumbnailer;
 import io.github.makbn.jthumbnail.core.util.mime.MimeTypeDetector;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -14,13 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.experimental.NonFinal;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.context.annotation.DependsOn;
-import org.springframework.stereotype.Component;
 
 /**
  * This class manages all available Thumbnailers.

--- a/src/main/java/io/github/makbn/jthumbnail/core/config/ExecutorConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/config/ExecutorConfiguration.java
@@ -4,6 +4,7 @@ import io.github.makbn.jthumbnail.core.properties.AsyncProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;

--- a/src/main/java/io/github/makbn/jthumbnail/core/config/JodConverterConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/config/JodConverterConfiguration.java
@@ -8,6 +8,7 @@ import io.github.makbn.jthumbnail.core.thumbnailers.OpenOfficeThumbnailer;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import org.jodconverter.core.office.OfficeManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/io/github/makbn/jthumbnail/core/config/OfficeManagerConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/config/OfficeManagerConfiguration.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
+
 import org.jodconverter.core.office.OfficeException;
 import org.jodconverter.core.office.OfficeManager;
 import org.jodconverter.local.office.ExistingProcessAction;
@@ -18,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 
 @Slf4j
 @Configuration

--- a/src/main/java/io/github/makbn/jthumbnail/core/config/ThumbnailServerConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/config/ThumbnailServerConfiguration.java
@@ -1,15 +1,16 @@
 package io.github.makbn.jthumbnail.core.config;
 
 import io.github.makbn.jthumbnail.core.properties.ThumbnailServerProperties;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 @Slf4j
 @Configuration
@@ -42,7 +43,6 @@ public class ThumbnailServerConfiguration {
 
         return temporaryDirectory;
     }
-
 
     public int getMaxWaitingListSize() {
         return thumbnailServerProperties.maxWaitingListSize();

--- a/src/main/java/io/github/makbn/jthumbnail/core/model/ThumbnailCandidate.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/model/ThumbnailCandidate.java
@@ -1,12 +1,13 @@
 package io.github.makbn.jthumbnail.core.model;
 
 import jakarta.validation.constraints.NotNull;
-import java.io.File;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
+
+import java.io.File;
 
 /**
  * @author Matt Akbarian (makbn)

--- a/src/main/java/io/github/makbn/jthumbnail/core/model/ThumbnailEvent.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/model/ThumbnailEvent.java
@@ -1,11 +1,12 @@
 package io.github.makbn.jthumbnail.core.model;
 
-import java.io.File;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+
+import java.io.File;
 
 @Builder
 @Getter

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/AsyncProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/AsyncProperties.java
@@ -2,6 +2,7 @@ package io.github.makbn.jthumbnail.core.properties;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/OfficeProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/OfficeProperties.java
@@ -25,7 +25,7 @@ import java.util.List;
 public record OfficeProperties(
         File officeHome,
         File workingDir,
-        @Name("port") @NotNull List<@Min(1) @Max(65535) Integer> ports,
+        @NotNull List<@Min(1) @Max(65535) Integer> ports,
         @NotNull @Min(1) Integer maxTasksPerProcess,
         @NotNull @Min(1) Long timeout,
         @NotNull File tmpDir) {

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/OfficeProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/OfficeProperties.java
@@ -3,8 +3,8 @@ package io.github.makbn.jthumbnail.core.properties;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.bind.Name;
 import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
@@ -28,5 +28,4 @@ public record OfficeProperties(
         @NotNull List<@Min(1) @Max(65535) Integer> ports,
         @NotNull @Min(1) Integer maxTasksPerProcess,
         @NotNull @Min(1) Long timeout,
-        @NotNull File tmpDir) {
-}
+        @NotNull File tmpDir) {}

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/OpenAPIProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/OpenAPIProperties.java
@@ -2,10 +2,12 @@ package io.github.makbn.jthumbnail.core.properties;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.net.URI;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
+
+import java.net.URI;
 
 /**
  * OpenAPI properties containing the fields used on Swagger page

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/ThumbnailProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/ThumbnailProperties.java
@@ -2,6 +2,7 @@ package io.github.makbn.jthumbnail.core.properties;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 

--- a/src/main/java/io/github/makbn/jthumbnail/core/properties/ThumbnailServerProperties.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/properties/ThumbnailServerProperties.java
@@ -1,9 +1,11 @@
 package io.github.makbn.jthumbnail.core.properties;
 
 import jakarta.validation.constraints.NotNull;
-import java.io.File;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.io.File;
 
 /**
  * Configuration properties for API Thumbnail server
@@ -12,5 +14,4 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @ConfigurationProperties(prefix = "jthumbnailer.server", ignoreUnknownFields = false)
-public record ThumbnailServerProperties(@NotNull File uploadDirectory,
-                                        @NotNull int maxWaitingListSize) {}
+public record ThumbnailServerProperties(@NotNull File uploadDirectory, @NotNull int maxWaitingListSize) {}

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/AbstractThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/AbstractThumbnailer.java
@@ -23,6 +23,7 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
 import java.io.File;
 import java.io.IOException;
 

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/DWGThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/DWGThumbnailer.java
@@ -3,14 +3,17 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.ResizeImage;
+
+import org.springframework.stereotype.Component;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+
 import javax.imageio.ImageIO;
-import org.springframework.stereotype.Component;
 
 @Component
 public class DWGThumbnailer extends AbstractThumbnailer {

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/ExcelConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/ExcelConverterThumbnailer.java
@@ -1,9 +1,11 @@
 package io.github.makbn.jthumbnail.core.thumbnailers;
 
-import com.spire.xls.FileFormat;
-import com.spire.xls.Workbook;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
+import com.spire.xls.FileFormat;
+import com.spire.xls.Workbook;
+
 import java.io.File;
 import java.nio.file.Files;
 

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/ImageThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/ImageThumbnailer.java
@@ -2,13 +2,15 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
-import java.io.File;
-import java.io.IOException;
 import net.coobird.thumbnailator.Thumbnails;
 import net.coobird.thumbnailator.resizers.configurations.Antialiasing;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * created by Mehdi Akbarian-Rastaghi 2018-10-23

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODConverterThumbnailer.java
@@ -5,10 +5,8 @@ import io.github.makbn.jthumbnail.core.properties.OfficeProperties;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.IOUtil;
 import io.github.makbn.jthumbnail.core.util.mime.MimeTypeDetector;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.utils.SystemUtils;
 import org.jodconverter.core.DocumentConverter;
@@ -17,6 +15,10 @@ import org.jodconverter.core.office.OfficeManager;
 import org.jodconverter.local.LocalConverter;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 @Slf4j
 @Component("jodConverter")

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODExcelThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODExcelThumbnailer.java
@@ -2,6 +2,7 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.properties.OfficeProperties;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
 import org.jodconverter.core.office.OfficeManager;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODHtmlConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/JODHtmlConverterThumbnailer.java
@@ -2,6 +2,7 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.properties.OfficeProperties;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
 import org.jodconverter.core.office.OfficeManager;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/MP3Thumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/MP3Thumbnailer.java
@@ -1,20 +1,24 @@
 package io.github.makbn.jthumbnail.core.thumbnailers;
 
+import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
+import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
 import com.mpatric.mp3agic.ID3v2;
 import com.mpatric.mp3agic.InvalidDataException;
 import com.mpatric.mp3agic.Mp3File;
 import com.mpatric.mp3agic.UnsupportedTagException;
-import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
-import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+
 import javax.imageio.ImageIO;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 /**
  * created by Mehdi Akbarian-Rastaghi 2018-10-23

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/MPEGThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/MPEGThumbnailer.java
@@ -4,18 +4,21 @@ import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailRuntimeException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.GifSequenceWriter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.springframework.stereotype.Component;
+
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+
 import javax.imageio.ImageIO;
 import javax.imageio.stream.FileImageOutputStream;
 import javax.imageio.stream.ImageOutputStream;
-import lombok.extern.slf4j.Slf4j;
-import org.bytedeco.javacv.FFmpegFrameGrabber;
-import org.springframework.stereotype.Component;
 
 /**
  * created by Matt Akbarian (makbn)

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/NativeImageThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/NativeImageThumbnailer.java
@@ -3,11 +3,14 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.ResizeImage;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
 import java.io.File;
 import java.io.IOException;
+
 import javax.imageio.ImageIO;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 /**
  * This class generates image thumbnails using native Java libraries.

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/OpenOfficeThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/OpenOfficeThumbnailer.java
@@ -5,17 +5,18 @@ import io.github.makbn.jthumbnail.core.exception.ThumbnailRuntimeException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.IOUtil;
 import io.github.makbn.jthumbnail.core.util.ResizeImage;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
-
-import lombok.experimental.FieldDefaults;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.stereotype.Component;
 
 /**
  * The OpenOfficeThumbnailer class is responsible for generating thumbnails for OpenOffice documents.

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/PDFBoxThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/PDFBoxThumbnailer.java
@@ -4,17 +4,20 @@ import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailRuntimeException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
 import io.github.makbn.jthumbnail.core.util.ResizeImage;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import javax.imageio.ImageIO;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.stereotype.Component;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.imageio.ImageIO;
 
 /**
  * Renders the first page of a PDF file into a thumbnail.

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/PowerpointConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/PowerpointConverterThumbnailer.java
@@ -1,15 +1,19 @@
 package io.github.makbn.jthumbnail.core.thumbnailers;
 
-import com.spire.presentation.Presentation;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailRuntimeException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+
+import com.spire.presentation.Presentation;
+
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
+
 import javax.imageio.ImageIO;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.stereotype.Component;
 
 /**
  * Dummy class for converting Presentation documents into Openoffice-Textfiles.

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/TextThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/TextThumbnailer.java
@@ -2,6 +2,9 @@ package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
+import org.springframework.stereotype.Component;
+
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -16,8 +19,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+
 import javax.imageio.ImageIO;
-import org.springframework.stereotype.Component;
 
 @Component
 public class TextThumbnailer extends AbstractThumbnailer {

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/Thumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/Thumbnailer.java
@@ -1,6 +1,7 @@
 package io.github.makbn.jthumbnail.core.thumbnailers;
 
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/WordConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/WordConverterThumbnailer.java
@@ -1,16 +1,20 @@
 package io.github.makbn.jthumbnail.core.thumbnailers;
 
-import com.spire.doc.Document;
-import com.spire.doc.documents.ImageType;
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
 import io.github.makbn.jthumbnail.core.properties.ThumbnailProperties;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Component;
+
+import com.spire.doc.Document;
+import com.spire.doc.documents.ImageType;
+
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+
 import javax.imageio.ImageIO;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.stereotype.Component;
 
 /**
  * Dummy class for converting Text documents into Openoffice-Textfiles.

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/GifSequenceWriter.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/GifSequenceWriter.java
@@ -2,6 +2,7 @@ package io.github.makbn.jthumbnail.core.util;
 
 import java.awt.image.RenderedImage;
 import java.io.IOException;
+
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageTypeSpecifier;

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/IOUtil.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/IOUtil.java
@@ -1,12 +1,13 @@
 package io.github.makbn.jthumbnail.core.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.zip.ZipFile;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility class for handling IO operations, such as closing resources or deleting files.

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/ResizeImage.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/ResizeImage.java
@@ -1,6 +1,9 @@
 package io.github.makbn.jthumbnail.core.util;
 
 import io.github.makbn.jthumbnail.core.exception.UnsupportedInputFileFormatException;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -9,9 +12,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
+
 import javax.imageio.ImageIO;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ResizeImage {

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/DocFileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/DocFileIdentifier.java
@@ -1,10 +1,12 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.poi.hwpf.HWPFDocument;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import lombok.extern.log4j.Log4j2;
-import org.apache.poi.hwpf.HWPFDocument;
 
 @Log4j2
 public class DocFileIdentifier extends OfficeFileIdentifier {

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MP3FileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MP3FileIdentifier.java
@@ -1,10 +1,11 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
 
 /**
  * created by Mehdi Akbarian-Rastaghi 2018-10-23

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MPEGFileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MPEGFileIdentifier.java
@@ -1,10 +1,11 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
 
 /**
  * created by Mehdi Akbarian-Rastaghi 2018-10-23

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
@@ -1,6 +1,11 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
 import io.github.makbn.jthumbnail.core.exception.ThumbnailException;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.tika.Tika;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -8,9 +13,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.tika.Tika;
 
 /**
  * Wrapper class for MIME Identification of Files.

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/Office2007FileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/Office2007FileIdentifier.java
@@ -1,5 +1,7 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -9,7 +11,6 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Add detection of Office2007 files (and OpenOffice files).

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/OfficeFileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/OfficeFileIdentifier.java
@@ -1,10 +1,11 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Improve detection of non-XML Office files.

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/PptFileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/PptFileIdentifier.java
@@ -1,11 +1,13 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import lombok.extern.log4j.Log4j2;
-import org.apache.poi.hslf.usermodel.HSLFSlideShow;
-import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
 
 @Log4j2
 public class PptFileIdentifier extends OfficeFileIdentifier {

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/XlsFileIdentifier.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/XlsFileIdentifier.java
@@ -1,11 +1,13 @@
 package io.github.makbn.jthumbnail.core.util.mime;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
 
 @Slf4j
 public class XlsFileIdentifier extends OfficeFileIdentifier {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ jthumbnailer:
     max_waiting_list_size: 1000
 
   openoffice:
-    port:
+    ports:
       - 2002
       - 2003
       - 2004

--- a/src/test/java/io/github/makbn/jthumbnail/OpenOfficeTest.java
+++ b/src/test/java/io/github/makbn/jthumbnail/OpenOfficeTest.java
@@ -4,10 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.github.makbn.jthumbnail.core.properties.OfficeProperties;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import lombok.extern.log4j.Log4j2;
+
 import org.jodconverter.core.DocumentConverter;
 import org.jodconverter.core.office.OfficeException;
 import org.jodconverter.core.office.OfficeManager;
@@ -23,6 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Log4j2
 @ExtendWith(SpringExtension.class)

--- a/src/test/java/io/github/makbn/jthumbnail/ThumbnailerTest.java
+++ b/src/test/java/io/github/makbn/jthumbnail/ThumbnailerTest.java
@@ -6,14 +6,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import io.github.makbn.jthumbnail.core.JThumbnailer;
 import io.github.makbn.jthumbnail.core.listener.ThumbnailListener;
 import io.github.makbn.jthumbnail.core.model.ThumbnailCandidate;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.log4j.Log4j2;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,6 +16,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.modulith.core.ApplicationModules;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 @SpringBootTest
 @Log4j2

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,9 +6,9 @@ jthumbnailer.openapi.desc = A thumbnail generation Java library for Office, PDF,
 jthumbnailer.openapi.license-url = https://github.com/makbn/JThumbnail/blob/master/LICENSE
 
 jthumbnailer.server.upload_directory = /tmp/upload
-jthumbnailer.openoffice.port[0] = 2002
-jthumbnailer.openoffice.port[1] = 2003
-jthumbnailer.openoffice.port[2] = 2004
+jthumbnailer.openoffice.ports[0] = 2002
+jthumbnailer.openoffice.ports[1] = 2003
+jthumbnailer.openoffice.ports[2] = 2004
 jthumbnailer.openoffice.timeout = 300000
 jthumbnailer.openoffice.max_tasks_per_process = 25
 jthumbnailer.openoffice.tmp = /tmp


### PR DESCRIPTION
This PR contains three changes:
1. Change the name for OpenOffice ports property to match the purpose, as it holds the **ports** to start OpenOffie on
2. Update the properties part in README
3. Update style to avoid clash with IntelliJ format on save 