### PR TITLE
fix(docs): fix javadoc generation and package it along sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+    withJavadocJar()
+    withSourcesJar()
 }
 publishing {
     publications {

--- a/src/main/java/io/github/makbn/jthumbnail/core/ThumbnailerManager.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/ThumbnailerManager.java
@@ -174,9 +174,11 @@ public class ThumbnailerManager implements Thumbnailer {
      * Try all available Thumbnailers and use the first that returns an image.
      * <p>
      * MIME-Detection narrows the selection of Thumbnailers to try:
-     * <li>First all Thumbnailers that declare to accept such a MIME Type are used
-     * <li>Then all Thumbnailers that declare to accept all possible MIME Types.
-     *
+     * <ul>
+     * <li>First all Thumbnailers that declare to accept such a MIME Type are used</li>
+     * <li>Then all Thumbnailers that declare to accept all possible MIME Types.</li>
+     * </ul>
+     * 
      * @param input    Input file that should be processed
      * @param output   File in which should be written
      * @param mimeType MIME-Type of input file (null if unknown)
@@ -232,8 +234,10 @@ public class ThumbnailerManager implements Thumbnailer {
      * Try all available Thumbnailers and use the first that returns an image.
      * <p>
      * MIME-Detection narrows the selection of Thumbnailers to try:
-     * <li>First all Thumbnailers that declare to accept such a MIME Type are used
-     * <li>Then all Thumbnailers that declare to accept all possible MIME Types.
+     * <ul>
+     * <li>First all Thumbnailers that declare to accept such a MIME Type are used</li>
+     * <li>Then all Thumbnailers that declare to accept all possible MIME Types.</li>
+     * </ul>
      *
      * @param input  Input file that should be processed
      * @param output File in which should be written

--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/AbstractThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/AbstractThumbnailer.java
@@ -29,10 +29,12 @@ import java.io.IOException;
 /**
  * This AbstractThumbnailer may be used in order to implement only essential
  * methods. It
- * <li>stores the current thumbnail height/width
- * <li>implements an empty close method
- * <li>specifies a wildcard MIME Type as appropriate Filetype
- *
+ * <ul>
+ * <li>stores the current thumbnail height/width</li>
+ * <li>implements an empty close method</li>
+ * <li>specifies a wildcard MIME Type as appropriate Filetype</li>
+ * </ul>
+ * 
  * @author Mehdi Akbarian-Rastaghi
  */
 public abstract class AbstractThumbnailer implements Thumbnailer {


### PR DESCRIPTION
When working with _JThumbnail_ as a library, it's interesting to be able to browse _Javadoc_ and sources from your IDE.

This PR provides the way to publish both along the standard _jar_.

As a consequence of enabling this,  _Javadoc_ inside project had to be fixed to conform to HTML format.