### PR TITLE
fix(npe): use the OS temp directory when working dir is not provided

### DIFF
--- a/src/main/java/io/github/makbn/jthumbnail/core/config/OfficeManagerConfiguration.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/config/OfficeManagerConfiguration.java
@@ -8,6 +8,7 @@ import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.io.FileUtils;
 import org.jodconverter.core.office.OfficeException;
 import org.jodconverter.core.office.OfficeManager;
 import org.jodconverter.local.office.ExistingProcessAction;
@@ -37,6 +38,11 @@ public class OfficeManagerConfiguration {
             Path temporaryPath;
             try {
                 File workingDirPath = officeProperties.workingDir();
+
+                if (workingDirPath == null) {
+                    // We use the OS temporary directory
+                    workingDirPath = FileUtils.getTempDirectory();
+                }
 
                 if (!workingDirPath.exists()) {
                     log.info("Working directory doesn't exist, creating it");

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -11,7 +11,7 @@ jthumbnailer.openoffice.ports[1] = 2003
 jthumbnailer.openoffice.ports[2] = 2004
 jthumbnailer.openoffice.timeout = 300000
 jthumbnailer.openoffice.max_tasks_per_process = 25
-jthumbnailer.openoffice.tmp = /tmp
+jthumbnailer.openoffice.tmp_dir = /tmp
    
 #jthumbnailer.openoffice.dir=/Users/mehdiakbarian/tools/soffice/OpenOffice.app/Contents/
 #jthumbnailer.openoffice.tmp=/private/tmp/jt


### PR DESCRIPTION
This PR fixes #37 by using OS temp dir when _working\_dir_ OpenOffice configuration parameter is not provided.
This mimics the way JODConverter when no working directory is provided.

