### PR TITLE
fix(resource closing): add missing finally block for closing document

### DIFF
--- a/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/WordConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/thumbnailers/WordConverterThumbnailer.java
@@ -69,6 +69,8 @@ public class WordConverterThumbnailer extends AbstractThumbnailer {
                     "Got an unexpected exception with message {}, throwing ThumbnailException",
                     e.getLocalizedMessage());
             throw new ThumbnailException(e);
+        } finally {
+            doc.close();
         }
     }
 


### PR DESCRIPTION
As other resources from Spire, there is a cleanup method.
I added this after experiencing Java Heap Space when running JThumbnail as library.