### PR TITLE
Fix/no such element exception

### DIFF
--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
@@ -124,7 +124,8 @@ public class MimeTypeDetector {
                 extensions.add("ppsx");
                 extensions.add("potx");
             }
-            case "application/vnd.openxmlformats-officedocument.spreadsheetml" -> {
+            case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml" -> {
                 extensions.add("xlsx");
                 extensions.add("xltx");
             }

--- a/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
+++ b/src/main/java/io/github/makbn/jthumbnail/core/util/mime/MimeTypeDetector.java
@@ -99,7 +99,7 @@ public class MimeTypeDetector {
     public String getStandardExtensionForMimeType(String mimeType) {
         List<String> extensions = getExtensionsCached(mimeType);
 
-        if (extensions == null) return null;
+        if (extensions == null || extensions.size() == 0) return null;
 
         try {
             return extensions.getFirst();


### PR DESCRIPTION
When using specific Excel file, _NoSuchElementException_ exception is thrown.
It seems that, for few cases, the _extensions_ array list is not null but empty.
In this case, we end up on the _getFirst()_ which throws the exception.